### PR TITLE
CSS Example Notebook

### DIFF
--- a/notebooks/Example Plot Styling.ipynb
+++ b/notebooks/Example Plot Styling.ipynb
@@ -1,0 +1,116 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "id": "479b2d4d",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5e3c802cb6b94714815f40db5263a893",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "LayoutWidget(controls={'toolbar_selection_tools': BasicJupyterToolbar(tools_data={'bqplot:home': {'tooltip': '…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from glue_jupyter.bqplot.scatter import BqplotScatterView\n",
+    "from glue_jupyter import JupyterApplication\n",
+    "from glue.core import Data\n",
+    "\n",
+    "app = JupyterApplication()\n",
+    "\n",
+    "# Setup some random data\n",
+    "def add_random_data():\n",
+    "    rand_data = Data(distance=np.random.sample(10) * 2e6,\n",
+    "                     velocity=np.random.sample(10) * 1000,\n",
+    "                     label='random_data' + str(len(app.data_collection)))\n",
+    "    app.data_collection.append(rand_data)\n",
+    "    \n",
+    "add_random_data()\n",
+    "add_random_data()\n",
+    "\n",
+    "# For different data sets to be shown on the same figure, their respective\n",
+    "# data components have to be linked.\n",
+    "app.add_link(app.data_collection[0], 'distance', app.data_collection[1], 'distance')\n",
+    "app.add_link(app.data_collection[0], 'velocity', app.data_collection[1], 'velocity')\n",
+    "\n",
+    "# This would be equivalent to the items in `app.viewers`\n",
+    "viewer = app.new_data_viewer(\n",
+    "    BqplotScatterView,\n",
+    "    show=True)\n",
+    "\n",
+    "viewer.add_data('random_data0')\n",
+    "viewer.add_data('random_data1')\n",
+    "\n",
+    "figure = viewer.figure_widget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "id": "a1d173ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "figure.background_style = {'fill': '#ccc'}\n",
+    "figure.fig_margin = {'left': 100, 'bottom': 60, 'top': 10, 'right': 10}\n",
+    "\n",
+    "# x axis\n",
+    "figure.axes[0].grid_color = '#FF5733'\n",
+    "figure.axes[0].tick_style = {'font-family': \"Courier New\"}\n",
+    "\n",
+    "# y axis\n",
+    "figure.axes[1].tick_format = '1.2e'\n",
+    "figure.axes[1].tick_style = {'font-family': \"Times New Roman\",\n",
+    "                             'font-size': 18}\n",
+    "figure.axes[1].label_offset = '75px'\n",
+    "figure.axes[1].grid_lines = 'solid'\n",
+    "figure.axes[1].label_style = {'font-family': \"Times New Roman\"}\n",
+    "\n",
+    "# marker style\n",
+    "figure.axes[1].tick_values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac8dd43c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/Example Plot Styling.ipynb
+++ b/notebooks/Example Plot Styling.ipynb
@@ -2,16 +2,24 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 1,
    "id": "479b2d4d",
    "metadata": {
     "scrolled": false
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/nmearl/.pyenv/versions/3.9.1/envs/cosmicds/lib/python3.9/site-packages/glue/external/echo/__init__.py:3: UserWarning: glue.external.echo is deprecated, import from echo directly instead\n",
+      "  warnings.warn('glue.external.echo is deprecated, import from echo directly instead')\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e82da5e335e54cd08c2d0d76566d5242",
+       "model_id": "94c13e0e2efd4f7ca6ecb20eba5486b5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -60,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 4,
    "id": "a1d173ff",
    "metadata": {},
    "outputs": [],
@@ -75,7 +83,7 @@
     "figure.axes[0].label = \"Overwrite the label text\"\n",
     "\n",
     "# y axis\n",
-    "figure.axes[1].tick_format = '1.2e'\n",
+    "figure.axes[1].tick_format = ',.2f'  # Or, if you don't want any decimals, use just ','\n",
     "figure.axes[1].tick_style = {'font-family': \"Times New Roman\",\n",
     "                             'font-size': 18}\n",
     "figure.axes[1].label_offset = '75px'\n",

--- a/notebooks/Example Plot Styling.ipynb
+++ b/notebooks/Example Plot Styling.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 38,
    "id": "479b2d4d",
    "metadata": {
     "scrolled": false
@@ -11,7 +11,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5e3c802cb6b94714815f40db5263a893",
+       "model_id": "e82da5e335e54cd08c2d0d76566d5242",
        "version_major": 2,
        "version_minor": 0
       },
@@ -46,7 +46,7 @@
     "app.add_link(app.data_collection[0], 'distance', app.data_collection[1], 'distance')\n",
     "app.add_link(app.data_collection[0], 'velocity', app.data_collection[1], 'velocity')\n",
     "\n",
-    "# This would be equivalent to the items in `app.viewers`\n",
+    "# This would be equivalent to the items in `app._viewer_handlers`\n",
     "viewer = app.new_data_viewer(\n",
     "    BqplotScatterView,\n",
     "    show=True)\n",
@@ -54,22 +54,25 @@
     "viewer.add_data('random_data0')\n",
     "viewer.add_data('random_data1')\n",
     "\n",
+    "# This is equivalent to the an item in `app.viewers`\n",
     "figure = viewer.figure_widget"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 39,
    "id": "a1d173ff",
    "metadata": {},
    "outputs": [],
    "source": [
-    "figure.background_style = {'fill': '#ccc'}\n",
+    "figure.background_style = {'fill': '#FCFFB8'}\n",
     "figure.fig_margin = {'left': 100, 'bottom': 60, 'top': 10, 'right': 10}\n",
     "\n",
     "# x axis\n",
     "figure.axes[0].grid_color = '#FF5733'\n",
+    "figure.axes[0].grid_lines = 'dashed'\n",
     "figure.axes[0].tick_style = {'font-family': \"Courier New\"}\n",
+    "figure.axes[0].label = \"Overwrite the label text\"\n",
     "\n",
     "# y axis\n",
     "figure.axes[1].tick_format = '1.2e'\n",
@@ -79,14 +82,16 @@
     "figure.axes[1].grid_lines = 'solid'\n",
     "figure.axes[1].label_style = {'font-family': \"Times New Roman\"}\n",
     "\n",
-    "# marker style\n",
-    "figure.axes[1].tick_values"
+    "# These settings are controlled by the glue state/layer classes\n",
+    "viewer.layers[0].scatter.marker = \"cross\"\n",
+    "viewer.layers[0].state.size = 8\n",
+    "viewer.layers[0].state.color = \"#00D387\""
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ac8dd43c",
+   "id": "e9770666",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Include is a css example notebook with some quick details on how to edit the css through the python interface. This does not include (yet) an example of how to edit the css using a style sheet.

<img width="982" alt="Screen Shot 2021-07-20 at 00 42 07" src="https://user-images.githubusercontent.com/4141126/126267965-4cacfdd8-92f7-4989-bd36-fd2d297fe1dc.png">
