### PR TITLE
Dialog component example

### DIFF
--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -13,6 +13,7 @@ from ipywidgets import widget_serialization
 from traitlets import Dict, List
 
 from .components.footer import Footer
+from .components.dialog import Dialog
 from .components.viewer_layout import ViewerLayout
 from .utils import load_template, update_figure_css
 
@@ -30,14 +31,27 @@ class Application(VuetifyTemplate):
     template = load_template("app.vue", __file__).tag(sync=True)
     viewers = Dict().tag(sync=True, **widget_serialization)
     items = List().tag(sync=True)
-    
+    vue_components = Dict().tag(sync=True, **widget_serialization)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         # Load the vue components through the ipyvuetify machinery. We add the
         # html tag we want and an instance of the component class as a 
         # key-value pair to the components dictionary.
-        self.components = {'c-footer': Footer(self)}
+        self.components = {'c-footer': Footer(self),
+                           'c-dialog-test1': Dialog(
+                               self,
+                               launch_button_text="Test 1",
+                               title_text="Test 1 Dialog",
+                               content_text="This is some random text.",
+                               accept_button_text="Accept"),
+                           'c-dialog-test2': Dialog(
+                               self,
+                               launch_button_text="Test 2",
+                               title_text="Test 2 Dialog",
+                               content_text="This is some more random text.",
+                               accept_button_text="Accept")}
 
         self.state = ApplicationState()
         self._application_handler = JupyterApplication()

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -109,7 +109,12 @@
                                       Assumed size:<br>
                                       Height of display:
                                     </v-card-text>
+
+                                    <v-card-actions>
+                                      <c-dialog-test2></c-dialog-test2>
+                                    </v-card-actions>
                                   </v-card>
+
                                 </v-col>
                               </v-row>
                           </v-container>
@@ -204,18 +209,20 @@
                   Open Snackbar
                 </v-btn>
 
+                <c-dialog-test1></c-dialog-test1>
+
                 <v-snackbar
                   v-model="state.snackbar"
                   style="position: absolute"
                   color="orange"
                   >
                Woohoo!
-                  <v-btn 
+                  <v-btn
                     color="cyan"
                     @click="state.snackbar=0">
                       Close
                   </v-btn>
-                </v-snackbar>   
+                </v-snackbar>
 
               </v-card-actions>
             </v-card>
@@ -224,7 +231,7 @@
         <c-footer />
       </v-container>
     </v-main>
-  </v-app>  
+  </v-app>
 </template>
 
 <style id="cosmicds-app">

--- a/cosmicds/components/dialog/__init__.py
+++ b/cosmicds/components/dialog/__init__.py
@@ -1,0 +1,1 @@
+from .dialog import *

--- a/cosmicds/components/dialog/dialog.py
+++ b/cosmicds/components/dialog/dialog.py
@@ -1,0 +1,26 @@
+from ipyvuetify import VuetifyTemplate
+from traitlets import Unicode, Bool
+
+from ...utils import load_template
+
+
+class Dialog(VuetifyTemplate):
+    template = load_template("dialog.vue", __file__).tag(sync=True)
+    dialog = Bool().tag(sync=True)
+    launch_button_text = Unicode().tag(sync=True)
+    title_text = Unicode().tag(sync=True)
+    content_text = Unicode().tag(sync=True)
+    accept_button_text = Unicode().tag(sync=True)
+
+    def __init__(self, app, launch_button_text, title_text, content_text,
+                 accept_button_text, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._app = app
+        self.launch_button_text = launch_button_text
+        self.title_text = title_text
+        self.content_text = content_text
+        self.accept_button_text = accept_button_text
+
+    def vue_accept_button_clicked(self, event):
+        self.dialog = False

--- a/cosmicds/components/dialog/dialog.vue
+++ b/cosmicds/components/dialog/dialog.vue
@@ -1,0 +1,36 @@
+<template>
+  <v-btn
+      color="primary"
+      dark
+      @click.stop="dialog = true"
+  >
+    {{ launch_button_text }}
+
+    <v-dialog
+        v-model="dialog"
+        max-width="500"
+    >
+      <v-card>
+        <v-card-title class="text-h5">
+          {{ title_text }}
+        </v-card-title>
+
+        <v-card-text>
+          {{ content_text }}
+        </v-card-text>
+
+        <v-card-actions>
+          <v-spacer></v-spacer>
+
+          <v-btn
+              color="green darken-1"
+              text
+              @click="accept_button_clicked"
+          >
+            {{ accept_button_text }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-btn>
+</template>

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
   pyqt5
   PyQtWebEngine
   qtpy
-  astropy
+  astropy < 4.3
   traitlets
   bqplot
   bqplot-image-gl


### PR DESCRIPTION
This PR includes an example of creating a dialog component, instances it in the `app.py` file, and referencing it in the `app.vue`. Note that there are _many_ ways to handle dialogs, and it may be easiest to simply include the Vue code directly without making a separate component.
