### PR TITLE
Figure styling example

### DIFF
--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -13,6 +13,7 @@ from ipywidgets import widget_serialization
 from traitlets import Dict, List
 
 from .components.footer import Footer
+from .components.viewer_layout import ViewerLayout
 from .utils import load_template, update_figure_css
 
 
@@ -51,15 +52,13 @@ class Application(VuetifyTemplate):
         self._application_handler.load_data(
             str(Path(__file__).parent / "data" / "hubble_simulation" /
                 "output" / "HubbleData_ClassSample.csv"),
-            label='HubbleData_ClassSample'
-        )
+            label='HubbleData_ClassSample')
 
         # Load some simulated age data
         self._application_handler.load_data(
             str(Path(__file__).parent / "data" / "hubble_simulation" /
                 "output" / "HubbleSummary_Overall.csv"),
-            label='HubbleSummary_Overall'
-        )
+            label='HubbleSummary_Overall')
 
         # Instantiate the initial viewers
         # Image viewer used for the 2D spectrum selection
@@ -90,7 +89,7 @@ class Application(VuetifyTemplate):
         hub_const_viewer.state.y_att = data.id['Velocity']
 
         # TODO: Currently, the glue-wwt package requires qt binding even if we
-        # only intend to use the juptyer viewer.
+        #  only intend to use the juptyer viewer.
         wwt_viewer = self._application_handler.new_data_viewer(
             WWTJupyterViewer, data=self.data_collection['galaxy_data'], show=False)
 
@@ -112,16 +111,13 @@ class Application(VuetifyTemplate):
             'age_distr_viewer': age_distr_viewer
         }
 
-        # wwt_viewer_layout = vuetify_layout_factory(wwt_viewer)
-
-        # Store a front-end accessible collection of renderable ipywidgets  
-        # These are the bqplot object itself (.figure_widget)
+        # Store a front-end accessible collection of renderable ipywidgets
         self.viewers = {
-            'image_viewer': image_viewer.figure_widget, 
-            'gal_viewer': gal_viewer.figure_widget, #scatter_viewer_layout,
-            'hub_const_viewer': hub_const_viewer.figure_widget, 
-            'wwt_viewer': wwt_viewer.figure_widget,  # wwt_viewer_layout
-            'age_distr_viewer': age_distr_viewer.figure_widget
+            'image_viewer': ViewerLayout(image_viewer),
+            'gal_viewer': ViewerLayout(gal_viewer),
+            'hub_const_viewer': ViewerLayout(hub_const_viewer),
+            'wwt_viewer': ViewerLayout(wwt_viewer),
+            'age_distr_viewer': ViewerLayout(age_distr_viewer)
         }
 
     def reload(self):

--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -1,25 +1,19 @@
 from pathlib import Path
-from uuid import uuid4
 
-import numpy as np
-from echo import CallbackProperty, DictCallbackProperty, ListCallbackProperty
-from echo.containers import CallbackList
-from glue.core import Data
+from echo import CallbackProperty
 from glue.core.state_objects import State
 from glue_jupyter.app import JupyterApplication
-from glue_jupyter.bqplot.image import BqplotImageView
-from glue_jupyter.bqplot.profile import BqplotProfileView
-from glue_jupyter.bqplot.scatter import BqplotScatterView
 from glue_jupyter.bqplot.histogram import BqplotHistogramView
+from glue_jupyter.bqplot.image import BqplotImageView
+from glue_jupyter.bqplot.scatter import BqplotScatterView
 from glue_jupyter.state_traitlets_helpers import GlueState
-from glue_jupyter.vuetify_layout import vuetify_layout_factory
 from glue_wwt.viewer.jupyter_viewer import WWTJupyterViewer
 from ipyvuetify import VuetifyTemplate
 from ipywidgets import widget_serialization
-from traitlets import Bool, Dict, Int, List
+from traitlets import Dict, List
 
-from .utils import load_template
 from .components.footer import Footer
+from .utils import load_template, update_figure_css
 
 
 class ApplicationState(State):
@@ -55,13 +49,15 @@ class Application(VuetifyTemplate):
 
         # Load some example simulated data
         self._application_handler.load_data(
-            str(Path(__file__).parent / "data" / "hubble_simulation" / "output" / "HubbleData_ClassSample.csv"),
+            str(Path(__file__).parent / "data" / "hubble_simulation" /
+                "output" / "HubbleData_ClassSample.csv"),
             label='HubbleData_ClassSample'
         )
 
         # Load some simulated age data
         self._application_handler.load_data(
-            str(Path(__file__).parent / "data" / "hubble_simulation" / "output" / "HubbleSummary_Overall.csv"),
+            str(Path(__file__).parent / "data" / "hubble_simulation" /
+                "output" / "HubbleSummary_Overall.csv"),
             label='HubbleSummary_Overall'
         )
 
@@ -73,6 +69,11 @@ class Application(VuetifyTemplate):
         # Scatter viewer used for the display of the measured galaxy data
         hub_const_viewer = self._application_handler.new_data_viewer(
             BqplotScatterView, data=self.data_collection['HubbleData_ClassSample'], show=False)
+
+        # Update the Hubble constant viewer CSS
+        update_figure_css(hub_const_viewer,
+                          style_path=Path(__file__).parent / "data" /
+                                     "styles" / "default_scatter.json")
 
         # Scatter viewer used for the galaxy selection
         gal_viewer = self._application_handler.new_data_viewer(

--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -69,6 +69,10 @@ class Application(VuetifyTemplate):
         hub_const_viewer = self._application_handler.new_data_viewer(
             BqplotScatterView, data=self.data_collection['HubbleData_ClassSample'], show=False)
 
+        data = self.data_collection['HubbleData_ClassSample']
+        hub_const_viewer.state.x_att = data.id['Distance']
+        hub_const_viewer.state.y_att = data.id['Velocity']
+
         # Update the Hubble constant viewer CSS
         update_figure_css(hub_const_viewer,
                           style_path=Path(__file__).parent / "data" /
@@ -81,12 +85,7 @@ class Application(VuetifyTemplate):
 
         # Histogram viewer for age distribution
         age_distr_viewer = self._application_handler.new_data_viewer(
-            BqplotHistogramView, data=self.data_collection['HubbleSummary_Overall'], show=False)        
-
-        # scatter_viewer.add_data(self.data_collection['HubbleData_ClassSample'])
-        data = self.data_collection['HubbleData_ClassSample']
-        hub_const_viewer.state.x_att = data.id['Distance']
-        hub_const_viewer.state.y_att = data.id['Velocity']
+            BqplotHistogramView, data=self.data_collection['HubbleSummary_Overall'], show=False)
 
         # TODO: Currently, the glue-wwt package requires qt binding even if we
         #  only intend to use the juptyer viewer.

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -68,7 +68,6 @@
                 <v-stepper-items class="">
                   <v-stepper-content step="1">
                     <jupyter-widget
-                      style="height: 300px"
                       :widget="viewers.hub_const_viewer"
                     ></jupyter-widget>
 

--- a/cosmicds/components/__init__.py
+++ b/cosmicds/components/__init__.py
@@ -1,0 +1,2 @@
+from .footer import *
+from .viewer_layout import *

--- a/cosmicds/components/viewer_layout/__init__.py
+++ b/cosmicds/components/viewer_layout/__init__.py
@@ -1,0 +1,1 @@
+from .viewer_layout import *

--- a/cosmicds/components/viewer_layout/viewer_layout.py
+++ b/cosmicds/components/viewer_layout/viewer_layout.py
@@ -1,0 +1,24 @@
+from ipyvuetify import VuetifyTemplate
+from ipywidgets import widget_serialization
+from traitlets import Dict, Instance
+from ipywidgets import DOMWidget
+
+from ...utils import load_template
+
+
+class ViewerLayout(VuetifyTemplate):
+    template = load_template("viewer_layout.vue", __file__).tag(sync=True)
+    controls = Dict().tag(sync=True, **widget_serialization)
+    figure = Instance(DOMWidget, allow_none=True).tag(sync=True, **widget_serialization)
+    css_style = Dict().tag(sync=True)
+
+    def __init__(self, viewer, style=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.controls = dict(
+            toolbar_selection_tools=viewer.toolbar_selection_tools,
+            toolbar_selection_mode=viewer.toolbar_selection_mode,
+            toolbar_active_subset=viewer.toolbar_active_subset)
+
+        self.css_style = style or {'height': '300px'}
+        self.figure = viewer.figure_widget

--- a/cosmicds/components/viewer_layout/viewer_layout.vue
+++ b/cosmicds/components/viewer_layout/viewer_layout.vue
@@ -1,0 +1,10 @@
+<template>
+  <v-card flat>
+    <v-toolbar flat short>
+      <v-toolbar-items>
+        <jupyter-widget :widget="controls.toolbar_selection_tools"></jupyter-widget>
+      </v-toolbar-items>
+    </v-toolbar>
+    <jupyter-widget :style="css_style" :widget="figure"></jupyter-widget>
+  </v-card>
+</template>

--- a/cosmicds/data/styles/default_scatter.json
+++ b/cosmicds/data/styles/default_scatter.json
@@ -1,0 +1,44 @@
+{
+  "figure": {
+    "background_style": {
+      "fill": "#FCFFB8"
+    },
+    "fig_margin": {
+      "left": 100,
+      "bottom": 60,
+      "top": 10,
+      "right": 10
+    },
+    "axes": [
+      {
+        "grid_color": "#FF5733",
+        "grid_lines": "dashed",
+        "tick_style": {
+          "font-family": "Courier New"
+        },
+        "label": "Overwrite the label text"
+      },
+      {
+        "tick_format": ",.2f",
+        "tick_style": {
+          "font-family": "Times New Roman",
+          "font-size": 18
+        },
+        "label_offset": "75px",
+        "grid_lines": "solid",
+        "label_style": {
+          "font-family": "Times New Roman"
+        }
+      }
+    ]
+  },
+  "viewer": {
+    "scatter": {
+      "marker": "cross"
+    },
+    "state": {
+      "size": 8,
+      "color": "#00D387"
+    }
+  }
+}

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -1,5 +1,6 @@
 import os
 from traitlets import Unicode
+import json
 
 __all__ = ['load_template']
 
@@ -31,3 +32,46 @@ def load_template(file_name, path=None, traitlet=True):
         return Unicode(TEMPLATE)
 
     return TEMPLATE
+
+
+def update_figure_css(viewer, style_dict=None, style_path=None):
+    """
+    Update the css of a BqPlot `~bqplot.figure.Figure` object.
+
+    Parameters
+    ----------
+    viewer : `~glue_jupyter.bqplot.scatter.viewer.BqplotScatterView`
+        The glue jupyter BqPlot viewer wrapper instance.
+    style_dict : dict
+        A dictionary containing the css attributes to be updated.
+    style_path : string or `~pathlib.Path`
+        A path to the ``.json`` file containing the css attributes to be
+        parsed into a dictionary.
+    """
+    figure = viewer.figure_widget
+
+    if style_path is not None:
+        with open(style_path) as f:
+            style_dict = json.load(f)
+
+    fig_styles = style_dict.get('figure')
+    viewer_styles = style_dict.get('viewer')
+
+    # Update figure styles
+    for k, v in fig_styles.items():
+        # Update axes styles
+        if k == 'axes':
+            for ak, av in fig_styles.get('axes')[0].items():
+                setattr(figure.axes[0], ak, av)
+
+            for ak, av in fig_styles.get('axes')[1].items():
+                setattr(figure.axes[1], ak, av)
+        else:
+            setattr(figure, k, v)
+
+    # Update viewer styles
+    for prop in viewer_styles:
+        for k, v in viewer_styles.get(prop, {}).items():
+            viewer_prop = getattr(viewer.layers[0], prop)
+            setattr(viewer_prop, k, v)
+

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -2,7 +2,7 @@ import os
 from traitlets import Unicode
 import json
 
-__all__ = ['load_template']
+__all__ = ['load_template', 'update_figure_css']
 
 
 def load_template(file_name, path=None, traitlet=True):
@@ -74,4 +74,3 @@ def update_figure_css(viewer, style_dict=None, style_path=None):
         for k, v in viewer_styles.get(prop, {}).items():
             viewer_prop = getattr(viewer.layers[0], prop)
             setattr(viewer_prop, k, v)
-

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -1,6 +1,8 @@
-import os
-from traitlets import Unicode
 import json
+import os
+
+import numpy as np
+from traitlets import Unicode
 
 __all__ = ['load_template', 'update_figure_css']
 
@@ -62,9 +64,15 @@ def update_figure_css(viewer, style_dict=None, style_path=None):
         # Update axes styles
         if k == 'axes':
             for ak, av in fig_styles.get('axes')[0].items():
+                if ak == 'tick_values':
+                    av = np.array(av)
+
                 setattr(figure.axes[0], ak, av)
 
             for ak, av in fig_styles.get('axes')[1].items():
+                if ak == 'tick_values':
+                    av = np.array(av)
+
                 setattr(figure.axes[1], ak, av)
         else:
             setattr(figure, k, v)


### PR DESCRIPTION
This PR adds a utility function that helps define figure/viewer css values. The style information is defined in the `default_scatter.json` file, and is thereafter parsed and used to update the `hub_const_viewer` viewer. It is also possible to pass a simple python dictionary (in the say style as the json file) to the `update_figure_css` utility function.
