### PR TITLE
Pure Vue components

### DIFF
--- a/cosmicds/__init__.py
+++ b/cosmicds/__init__.py
@@ -2,3 +2,15 @@
 
 from .version import __version__
 __all__ = []
+
+# Register any custom Vue components
+from pathlib import Path
+import ipyvue
+
+vue_comp_dir = Path(__file__).parent / "data" / "vue_components"
+
+for comp_path in vue_comp_dir.iterdir():
+    if comp_path.suffix == ".vue":
+        ipyvue.register_component_from_string(
+            name=comp_path.stem.replace('_', '-'),
+            value=comp_path.read_text())

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -263,6 +263,17 @@
                           width="100%"
                         >
                           Buttons to calculate age of universe from H0 value.<br>
+
+                          <help-dialog 
+                            button-text="Click Me!" 
+                            title-text="Testing!" 
+                            accept-text="Okay" 
+                            cancel-text="Cancel" 
+                            @accept="console.log('Button was clicked.')"
+                          >
+                            This is a test of a pure Vue dialog with a custom event.
+                          </help-dialog>
+
                         </v-card>
                      </v-row>
                     </v-container>

--- a/cosmicds/data/vue_components/help_dialog.vue
+++ b/cosmicds/data/vue_components/help_dialog.vue
@@ -1,0 +1,53 @@
+<template>
+  <v-btn
+      color="primary"
+      dark
+      @click.stop="dialog = true"
+  >
+    {{ buttonText }}
+
+    <v-dialog
+        v-model="dialog"
+        max-width="500"
+    >
+      <v-card>
+        <v-card-title class="text-h5">
+          {{ titleText }}
+        </v-card-title>
+
+        <v-card-text>
+          <slot></slot>
+        </v-card-text>
+
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn
+              text
+              @click="dialog = false"
+          >
+            {{ cancelText }}
+          </v-btn>
+
+          <v-btn
+              color="green darken-1"
+              text
+              @click="() => { $emit('accept'); dialog = false } "
+          >
+            {{ acceptText }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-btn>
+</template>
+
+<script>
+module.exports = {
+  props: ["buttonText", "titleText", "acceptText", "cancelText"],
+  data: function () {
+    return {
+      dialog: false,
+    };
+  },
+};
+</script>


### PR DESCRIPTION
This PR adds support for defining pure Vue components and using them within the broader application. Pure Vue components files (`.vue`) can be added to `data/vue_components` directory and will be used to populate the component registry on application instantiation.

The example component is a simple dialog box similar to the python-based dialog component that exists now. It also show how to implement a custom event within the component and expose it when the component is used in the `app.vue` template.

<img width="995" alt="Screen Shot 2021-08-07 at 15 44 33" src="https://user-images.githubusercontent.com/4141126/128613643-f691d2d7-6e73-4a1a-b7c7-eb728979dba2.png">
<img width="995" alt="Screen Shot 2021-08-07 at 15 44 42" src="https://user-images.githubusercontent.com/4141126/128613646-f0092594-09f7-4c1c-8a45-e4f22469c374.png">

