### PR TITLE
Create templates for learning objectives scaffolding

### DIFF
--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -82,7 +82,12 @@
                   </v-stepper-step>
                 </v-stepper-header>
               <!-- This sets up the screen for the galaxy selection/measurement step -->
-                <v-stepper-items class="">
+                <v-stepper-items
+                  class=""
+                >
+                  <!-- --- ---------- --- -->
+                  <!-- --- FIRST PAGE --- -->
+                  <!-- --- ---------- --- -->
                   <v-stepper-content step="1">
                     <v-container>
                       <v-row>
@@ -284,8 +289,21 @@
                             </v-row>
                           </v-container>
                         </v-tab-item>
-
                     </v-card>
+
+                    <!-- WIREFRAME for learning objectives/experience on First Page -->
+                    <hinttext-alert>
+                      This is for marginal hint text
+                    </hinttext-alert>
+                    <snackbar-alert>
+                      This is for guidance snackbars
+                    </snackbar-alert>
+                    <infodialog-alert>
+                      This is for informative dialog pop-ups
+                    </infodialog-alert>
+                    <responsedialog-alert>
+                      This is for worksheet form pop-ups
+                    </responsedialog-alert>
                   </v-stepper-content>
 
                 <!-- This sets up the screen for the Analysis/data fitting step -->
@@ -295,6 +313,9 @@
                      * Choosing different data sets - student/class/all
                      * Plotting by galaxy type -->
 
+                  <!-- --- ----------- --- -->
+                  <!-- --- SECOND PAGE --- -->
+                  <!-- --- ----------- --- -->
                   <v-stepper-content step="2">
                     <v-container>
                       <v-row>
@@ -333,6 +354,20 @@
                         </v-card>
                       </v-row>
                     </v-container>
+                    
+                    <!-- WIREFRAME for learning objectives/experience on First Page -->
+                    <hinttext-alert>
+                      This is for marginal hint text
+                    </hinttext-alert>
+                    <snackbar-alert>
+                      This is for guidance snackbars
+                    </snackbar-alert>
+                    <infodialog-alert>
+                      This is for informative dialog pop-ups
+                    </infodialog-alert>
+                    <responsedialog-alert>
+                      This is for worksheet form pop-ups
+                    </responsedialog-alert>
 <!-- Disabling for now
                     <v-btn color="primary" @click="state.over_model = 3">
                       Continue
@@ -345,6 +380,9 @@
                 <!-- Will need buttons/functionality for choosing different data sets -->
                 <!-- Need to think through whether the hubble plot should also appear on this page or if that would be confusing -->
 
+                  <!-- --- ---------- --- -->
+                  <!-- --- THIRD PAGE --- -->
+                  <!-- --- ---------- --- -->
                   <v-stepper-content step="3">
                     <v-container>
                       <v-row>
@@ -392,9 +430,26 @@
                         </v-card>
                      </v-row>
                     </v-container>
+                    
+                    <!-- WIREFRAME for learning objectives/experience on First Page -->
+                    <hinttext-alert>
+                      This is for marginal hint text
+                    </hinttext-alert>
+                    <snackbar-alert>
+                      This is for guidance snackbars
+                    </snackbar-alert>
+                    <infodialog-alert>
+                      This is for informative dialog pop-ups
+                    </infodialog-alert>
+                    <responsedialog-alert>
+                      This is for worksheet form pop-ups
+                    </responsedialog-alert>
 
                   </v-stepper-content>
 
+                  <!-- --- ----------- --- -->
+                  <!-- --- FOURTH PAGE --- -->
+                  <!-- --- ----------- --- -->
                   <v-stepper-content step="4">
                     <v-container>
                       <v-row>
@@ -458,6 +513,21 @@
                       class="fill-height mb-12"
                       color="grey lighten-1 elevation-0"
                     ></v-card>
+                    
+                    <!-- WIREFRAME for learning objectives/experience on First Page -->
+                    <hinttext-alert>
+                      This is for marginal hint text
+                    </hinttext-alert>
+                    <snackbar-alert>
+                      This is for guidance snackbars
+                    </snackbar-alert>
+                    <infodialog-alert>
+                      This is for informative dialog pop-ups
+                    </infodialog-alert>
+                    <responsedialog-alert>
+                      This is for worksheet form pop-ups
+                    </responsedialog-alert>
+                    
 <!-- disabling this because it's redundant with previous/next
                     <v-btn color="primary" @click="state.over_model = 1">
                       Continue

--- a/cosmicds/data/vue_components/hinttext_alert.vue
+++ b/cosmicds/data/vue_components/hinttext_alert.vue
@@ -1,0 +1,24 @@
+<template>
+  <v-alert
+    text
+    prominent
+    color="yellow darken-3"
+    icon="mdi-more"
+    class="pa-5 my-2 text-body-2"
+  >
+    <div>
+      <strong>Hint Text</strong>
+    </div>
+    <slot></slot>
+  </v-alert>
+</template>
+
+<script>
+module.exports = {
+  props: [],
+  data: function () {
+    return {
+    };
+  },
+};
+</script>

--- a/cosmicds/data/vue_components/infodialog_alert.vue
+++ b/cosmicds/data/vue_components/infodialog_alert.vue
@@ -1,0 +1,24 @@
+<template>
+  <v-alert
+    text
+    prominent
+    color="blue lighten-1"
+    icon="mdi-lightbulb-group-outline"
+    class="pa-5 my-2 text-body-2"
+  >
+    <div>
+      <strong>Information Dialog</strong>
+    </div>
+    <slot></slot>
+  </v-alert>
+</template>
+
+<script>
+module.exports = {
+  props: [],
+  data: function () {
+    return {
+    };
+  },
+};
+</script>

--- a/cosmicds/data/vue_components/responsedialog_alert.vue
+++ b/cosmicds/data/vue_components/responsedialog_alert.vue
@@ -1,0 +1,24 @@
+<template>
+  <v-alert
+    text
+    prominent
+    color="pink darken-1"
+    icon="mdi-format-list-numbered"
+    class="pa-5 my-2 text-body-2"
+  >
+    <div>
+      <strong>Worksheet Form Dialog</strong>
+    </div>
+    <slot></slot>
+  </v-alert>
+</template>
+
+<script>
+module.exports = {
+  props: [],
+  data: function () {
+    return {
+    };
+  },
+};
+</script>

--- a/cosmicds/data/vue_components/snackbar_alert.vue
+++ b/cosmicds/data/vue_components/snackbar_alert.vue
@@ -1,0 +1,24 @@
+<template>
+  <v-alert
+    text
+    prominent
+    color="green darken-2"
+    icon="mdi-alert-octagram-outline"
+    class="pa-5 my-2 text-body-2"
+  >
+    <div>
+      <strong>Guide Snackbar</strong>
+    </div>
+    <slot></slot>
+  </v-alert>
+</template>
+
+<script>
+module.exports = {
+  props: [],
+  data: function () {
+    return {
+    };
+  },
+};
+</script>


### PR DESCRIPTION
4 templates have been created:
1. Hint-text: this would indicate where support text might feature next to an in-app object to help students understand how to interact with it.
2. Snackbar-guide: This would pop up based on students reaching checkpoints, in order to guide them to next steps
3. Informational-dialog: This provides more in-depth explanation of information and goals for a particular objective. Students can open and close as they need.
4. Worksheet Form Dialog: This asks students to read/reflect/respond regarding learning objectives. Students cannot close until they have completed prompts.

Copy and Paste these sample templates at the end of each stepper page. List them in the order of the student learning experience, as linearly as possible (note: student experience may not always be linear).

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
