### PR TITLE
Fix issue with line marks not panning/zooming

### DIFF
--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -509,7 +509,7 @@ class Application(VuetifyTemplate):
         # Observe interaction changes so that we can modify when necessary
         # We want to remove any observers that we have previously set
         figure.interaction.unobserve_all(name='next')
-        figure.interaction.observe(lambda changed: self.panzoom_interaction_update(changed, viewer_id), names=['next'])
+        figure.interaction.observe(lambda changed: self._panzoom_interaction_update(changed, viewer_id), names=['next'])
 
     def _class_histogram_selection_update(self, selections):
         """
@@ -564,7 +564,7 @@ class Application(VuetifyTemplate):
         ]
         self._histogram_selection_update(selections, 'sandbox_distr_viewer', line_options=line_options)
 
-    def panzoom_interaction_update(self, change, viewer_id):
+    def _panzoom_interaction_update(self, change, viewer_id):
 
             viewer = self._viewer_handlers[viewer_id]
             figure = viewer.figure

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -2,7 +2,9 @@ import json
 import os
 
 from astropy import units as u
+from bqplot.scales import LinearScale
 from bqplot_image_gl import LinesGL
+from glue_jupyter.bqplot.histogram.layer_artist import BqplotHistogramLayerArtist
 from glue_jupyter.bqplot.scatter.layer_artist import BqplotScatterLayerArtist
 import numpy as np
 from traitlets import Unicode
@@ -135,8 +137,14 @@ def line_mark(layer, start_x, start_y, end_x, end_y, color):
     """
     if isinstance(layer, BqplotScatterLayerArtist):
         scales = layer.image.scales
-    else:
-        scales = layer.view.scales
+    elif isinstance(layer, BqplotHistogramLayerArtist):
+        layer_scales = layer.view.scales
+        layer_x = layer_scales['x']
+        layer_y = layer_scales['y']
+        scales = {
+            'x': LinearScale(min=layer_x.min, max=layer_x.max, allow_padding=layer_x.allow_padding),
+            'y': LinearScale(min=layer_y.min, max=layer_y.max, allow_padding=layer_y.allow_padding),
+        }
     return LinesGL(x=[start_x, end_x],
                    y=[start_y, end_y],
                    scales=scales,

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -2,7 +2,6 @@ import json
 import os
 
 from astropy import units as u
-from bqplot.scales import LinearScale
 from bqplot_image_gl import LinesGL
 from glue_jupyter.bqplot.scatter.layer_artist import BqplotScatterLayerArtist
 import numpy as np
@@ -135,15 +134,9 @@ def line_mark(layer, start_x, start_y, end_x, end_y, color):
         The desired color of the line, represented as a hex string.
     """
     if isinstance(layer, BqplotScatterLayerArtist):
-        layer_scales = layer.image.scales
+        scales = layer.image.scales
     else:
-        layer_scales = layer.view.scales
-    layer_x = layer_scales['x']
-    layer_y = layer_scales['y']
-    scales = {
-        'x': LinearScale(min=layer_x.min, max=layer_x.max, allow_padding=layer_x.allow_padding),
-        'y': LinearScale(min=layer_y.min, max=layer_y.max, allow_padding=layer_y.allow_padding),
-    }
+        scales = layer.view.scales
     return LinesGL(x=[start_x, end_x],
                    y=[start_y, end_y],
                    scales=scales,


### PR DESCRIPTION
While investigating the cause of https://github.com/glue-viz/cosmicds/issues/36, I noticed that the line marks currently don't pan/zoom with the data in the glue viewer. This PR fixes that issue.

For the scatter viewers, this was a simple as using the same `Scale` objects as the viewer does. However, for the histogram viewers, using the same scales had a small, but visually noticeable, effect on the y-axis scale (particularly in our default positioning, with the minimum of the y-axis at 0).

To work around this, I have the line marks on the histogram viewer use new `Scale` objects built on the viewer's scales, and attach them to the viewer's `bqplot.PanZoom` interaction when appropriate, so that the marks will pan/zoom with the scales correctly.