### PR TITLE
Histogram scatter sync

### DIFF
--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -583,9 +583,7 @@ class Application(VuetifyTemplate):
 
     def vue_clear_histogram_selection(self, _args):
         toolbar = self._viewer_handlers['class_distr_viewer'].toolbar
-        if toolbar._default_mouse_mode:
-            toolbar._default_mouse_mode.deactivate()
-        toolbar.tools['bqplot:xrange'].deactivate()
+        toolbar.active_tool = None
         self._histogram_listener.clear_subset()
 
     # These three properties provide convenient access to the slopes of the the fit lines

--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -474,10 +474,10 @@ class Application(VuetifyTemplate):
         viewer_id = 'hub_comparison_viewer'
         viewer = self._viewer_handlers[viewer_id]
         data = [self._student_data, self._class_data, self._all_data]
-        uuids = [x.uuid for (i,x) in enumerate(data) if i in selections]
+        labels = [x.label for (i,x) in enumerate(data) if i in selections]
 
         for layer in viewer.layers:
-            layer.state.visible = layer.state.layer.uuid in uuids
+            layer.state.visible = layer.state.layer.label in labels
         
         # We only want to show lines for the layers that are visible
         line_info = self._fit_lines.get(viewer_id, [])
@@ -485,7 +485,7 @@ class Application(VuetifyTemplate):
         
         figure = viewer.figure
         not_lines = [mark for mark in figure.marks if mark not in all_lines]
-        lines = [x[0] for x in line_info if x[1] in uuids]
+        lines = [x[0] for x in line_info if x[1] in labels]
         figure.marks = not_lines + lines
 
     def _histogram_selection_update(self, selections, viewer_id, line_options=[], layer_mapping=None):
@@ -535,14 +535,17 @@ class Application(VuetifyTemplate):
         selections : List[int]
             The indices of the selected options. The indices in this case represent:
             * 0: Individual students (glue layer)
-            * 1: Student's value (line mark)
-            * 2: Class's value (line mark)
+            * 1: Student's selected subset (glue layer) - only if student has made selection
+            * 1 or 2: Student's value (line mark)
+            * 2 or 3: Class's value (line mark)
         """
+
         line_options = [
             (1, self.student_slope, 'blue'),
             (2, self.class_slope, 'green')
         ]
         layer_mapping = { 0 : 0, 1 : 0 } # We hide a selected subset if the glue layer is hidden
+        print(selections)
         self._histogram_selection_update(selections, 'class_distr_viewer',
             layer_mapping=layer_mapping, line_options=line_options)
     
@@ -590,12 +593,12 @@ class Application(VuetifyTemplate):
     # for the student's data, the class's data, and all of the data
     @property
     def student_slope(self):
-        return self._fit_slopes.get(self._student_data.uuid)
+        return self._fit_slopes.get(self._student_data.label)
 
     @property
     def class_slope(self):
-        return self._fit_slopes.get(self._class_data.uuid)
+        return self._fit_slopes.get(self._class_data.label)
 
     @property
     def all_slope(self):
-        return self._fit_slopes.get(self._all_data.uuid)
+        return self._fit_slopes.get(self._all_data.label)

--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -149,9 +149,7 @@ class Application(VuetifyTemplate):
         hub_students_viewer.add_data(class_data)
         hub_students_viewer.state.x_att = class_data.id['distance']
         hub_students_viewer.state.y_att = class_data.id['velocity']
-        students_style_path = str(Path(__file__).parent / "data" /
-                                        "styles" / "students_scatter.json")
-        update_figure_css(hub_students_viewer, style_path=students_style_path)
+        update_figure_css(hub_students_viewer, style_path=style_path)
 
         # The Hubble comparison viewer should get the class and all public data as well
         all_data = self.data_collection['HubbleData_All']

--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -581,6 +581,12 @@ class Application(VuetifyTemplate):
         ]
         self._histogram_selection_update(selections, 'sandbox_distr_viewer', line_options=line_options)
 
+    def vue_clear_histogram_selection(self, _args):
+        toolbar = self._viewer_handlers['class_distr_viewer'].toolbar
+        if toolbar._default_mouse_mode:
+            toolbar._default_mouse_mode.deactivate()
+        toolbar.tools['bqplot:xrange'].deactivate()
+        self._histogram_listener.clear_subset()
 
     # These three properties provide convenient access to the slopes of the the fit lines
     # for the student's data, the class's data, and all of the data

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -644,7 +644,7 @@
                         <v-col>
                           <v-lazy>
                             <jupyter-widget
-                              :widget="viewers.hub_const_viewer"
+                              :widget="viewers.hub_students_viewer"
                             ></jupyter-widget>
                           </v-lazy>
                           <todo-alert>
@@ -688,7 +688,7 @@
                                             <v-list-item-action>
                                               <v-checkbox
                                                 :input-value="active"
-                                                :color="['orange', 'red', 'blue'][index]"
+                                                :color="['orange', 'blue', 'green'][index]"
                                               ></v-checkbox>
                                             </v-list-item-action>
                                           </template>

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -695,6 +695,12 @@
                                         </v-list-item>
                                       </v-list-item-group>
                                     </v-list>
+                                    <v-btn
+                                      color="primary"
+                                      @click="clear_histogram_selection()"
+                                    >
+                                    Clear selection
+                                    </v-btn>
                                   </v-col>
                                   <v-col>
                                     <v-lazy>

--- a/cosmicds/histogram_listener.py
+++ b/cosmicds/histogram_listener.py
@@ -21,3 +21,28 @@ class HistogramListener(SubsetModifierListener):
 
         return subset_mask
 
+    def _handle_message(self, message):
+
+        super()._handle_message(message)
+
+        # Add a fit line if the subset has a nonzero number of data points
+        # Otherwise, clear lines
+        if self._modify.size > 0:
+            viewer = self._app._viewer_handlers['hub_students_viewer']
+            layer_index = -1
+            for index, layer in enumerate(viewer.layers):
+                if layer.state.layer.label == self._modify.label:
+                    layer_index = index
+            
+            if layer_index < 0:
+                return
+
+            self._app.vue_fit_lines({
+                'viewer_id': 'hub_students_viewer',
+                'layers': [layer_index],
+                'clear_others': True,
+                'aggregate': False
+            })
+
+        else:
+            self._app.vue_clear_lines('hub_students_viewer')

--- a/cosmicds/histogram_listener.py
+++ b/cosmicds/histogram_listener.py
@@ -1,0 +1,49 @@
+from glue.core import Hub, HubListener, Data, DataCollection, data_collection, subset
+from glue.core.message import SubsetMessage, SubsetCreateMessage, SubsetDeleteMessage, SubsetUpdateMessage
+from glue.core.subset import MaskSubsetState
+
+from numpy import isin, unique
+
+class HistogramListener(HubListener):
+
+    def __init__(self, app, modify, source_data):
+        self._source_data = source_data
+        self._source = None
+        self._modify = modify
+        self._app = app
+        self._hub = app.data_collection.hub
+        self._hub.subscribe(self, SubsetMessage, handler=self.handle_message)
+
+    def _should_listen(self, message):
+        """
+        This method checks that a message is of the right type (SubsetMessage)
+        and that it was sent by the subset that we care about
+        """
+        if not isinstance(message, SubsetMessage):
+            return False
+        
+        if self._source is None:
+            return message.subset.data.uuid == self._source_data.uuid
+        else:
+            return message.subset == self._source
+        
+    def handle_message(self, message):
+
+        # Do we care about this message?
+        if not self._should_listen(message):
+            return
+
+        # If we do, get the student IDs present in the selected
+        # histogram bar(s)
+        subset = message.subset
+        self._source = self._source or subset
+        student_ids = list(unique(subset['student_id']))
+
+        data = self._modify.data
+        subset_mask = isin(data['student_id'], student_ids)
+        self._modify.subset_state = subset_mask
+        viewer = self._app._viewer_handlers['hub_students_viewer']
+        for layer in viewer.layers:
+            if layer.state.layer.label == self._source.label:
+                layer.state.visible = False
+         

--- a/cosmicds/histogram_listener.py
+++ b/cosmicds/histogram_listener.py
@@ -1,49 +1,23 @@
-from glue.core import Hub, HubListener, Data, DataCollection, data_collection, subset
-from glue.core.message import SubsetMessage, SubsetCreateMessage, SubsetDeleteMessage, SubsetUpdateMessage
-from glue.core.subset import MaskSubsetState
+from glue.core.message import SubsetDeleteMessage
+from numpy import array, isin, unique
 
-from numpy import isin, unique
+from .subset_modifier_listener import SubsetModifierListener
+class HistogramListener(SubsetModifierListener):
 
-class HistogramListener(HubListener):
+    def __init__(self, app, source, modify, source_viewer_ids=[], modify_viewer_ids=[], listen=True):
+        super().__init__(app, source, modify, source_viewer_ids, modify_viewer_ids, listen)
 
-    def __init__(self, app, modify, source_data):
-        self._source_data = source_data
-        self._source = None
-        self._modify = modify
-        self._app = app
-        self._hub = app.data_collection.hub
-        self._hub.subscribe(self, SubsetMessage, handler=self.handle_message)
+    def _create_mask(self, message):
 
-    def _should_listen(self, message):
-        """
-        This method checks that a message is of the right type (SubsetMessage)
-        and that it was sent by the subset that we care about
-        """
-        if not isinstance(message, SubsetMessage):
-            return False
-        
-        if self._source is None:
-            return message.subset.data.uuid == self._source_data.uuid
-        else:
-            return message.subset == self._source
-        
-    def handle_message(self, message):
-
-        # Do we care about this message?
-        if not self._should_listen(message):
-            return
+        # Handle delete messages slightly differently
+        subset = message.subset
+        if isinstance(message, SubsetDeleteMessage):
+            return array([False] * self._modify.size)
 
         # If we do, get the student IDs present in the selected
         # histogram bar(s)
-        subset = message.subset
-        self._source = self._source or subset
         student_ids = list(unique(subset['student_id']))
+        subset_mask = isin(self._modify.data['student_id'], student_ids)
 
-        data = self._modify.data
-        subset_mask = isin(data['student_id'], student_ids)
-        self._modify.subset_state = subset_mask
-        viewer = self._app._viewer_handlers['hub_students_viewer']
-        for layer in viewer.layers:
-            if layer.state.layer.label == self._source.label:
-                layer.state.visible = False
-         
+        return subset_mask
+

--- a/cosmicds/subset_modifier_listener.py
+++ b/cosmicds/subset_modifier_listener.py
@@ -1,0 +1,96 @@
+from glue.core import HubListener
+from glue.core.data import Data
+from glue.core.message import SubsetMessage, SubsetCreateMessage, SubsetDeleteMessage, SubsetUpdateMessage
+from glue.core.subset import Subset
+from glue.core.subset_group import SubsetGroup
+
+from numpy import array, isin, unique
+
+class SubsetModifierListener(HubListener):
+
+    def __init__(self, app, source, modify, source_viewer_ids=[], modify_viewer_ids=[], listen=True):
+        if isinstance(source, Data):
+            self._source_data = source
+            self._source = None
+        elif isinstance(source, Subset) or isinstance(source, SubsetGroup):
+            self._source = source
+            self._source_data = source.data
+        else:
+            raise ValueError("Source must be Data, Subset, or SubsetGroup")
+            
+        self._app = app
+        self._modify = modify
+        self._modify_viewer_ids = modify_viewer_ids or list(app._viewer_handlers.keys())
+        self._source_viewer_ids = source_viewer_ids or list(app._viewer_handlers.keys())
+        self._hub = app.data_collection.hub
+        if listen:
+            self.listen()
+
+    def listen(self):
+        self._hub.subscribe(self, SubsetMessage, handler=self._handle_message)
+
+    def ignore(self):
+        self._hub.unsubscribe(self, SubsetMessage)
+
+    def _should_listen(self, message):
+        """
+        This method checks that a message is of the right type (SubsetMessage)
+        and that it was sent by the subset that we care about
+        """
+        if not isinstance(message, SubsetMessage):
+            return False
+        
+        if self._source is None:
+            return message.subset.data.uuid == self._source_data.uuid
+        else:
+            return message.subset == self._source
+
+    def _create_mask(self, message):
+        raise NotImplementedError("Listener has no _create_mask method")
+
+    def _handle_message(self, message):
+
+        # Do we care about this message?
+        if not self._should_listen(message):
+            return
+
+        # If we don't have a source yet, it's the subset from this message
+        if self._source is None and isinstance(message, SubsetCreateMessage):
+            self._source = message.subset
+
+        # Get the subset mask and modify the subset
+        subset_mask = self._create_mask(message)
+        self._modify.subset_state = subset_mask
+        self._modify.style.color = self._source.style.color
+
+        # Since the subset created via the UI is really a SubsetGroup
+        # the subset state gets broadcast to all of the data sets
+        # In Qt glue, a viewer won't display this subset if it isn't based on
+        # attributes linked to the viewer's data. But this doesn't seem to be the
+        # case in glue-jupyter, so we handle this ourselves
+
+        viewers = self._app._viewer_handlers.items()
+        for key, viewer in viewers:
+            if key not in self._source_viewer_ids:
+
+                # We can't call remove_subset, since it's not the same subset in the other layer
+                # It's just a member of the same subset group
+                # But it will have the same label
+                for layer in viewer.layers:
+                    if layer.state.layer.label == self._source.label:
+                        layer.state.visible = False # Calling viewer.remove_layer(layer) doesn't work for some reason
+ 
+            # We also may want to control where the modified subset appears
+            if key not in self._modify_viewer_ids:
+                for layer in viewer.layers:
+                    if layer.state.layer.label == self._modify.label:
+                        layer.state.visible = False
+
+
+    @property
+    def source(self):
+        return self._source
+
+    @property
+    def modify(self):
+        return self._modify

--- a/cosmicds/subset_modifier_listener.py
+++ b/cosmicds/subset_modifier_listener.py
@@ -1,10 +1,8 @@
 from glue.core import HubListener
 from glue.core.data import Data
-from glue.core.message import SubsetMessage, SubsetCreateMessage, SubsetDeleteMessage, SubsetUpdateMessage
+from glue.core.message import SubsetMessage, SubsetCreateMessage, SubsetDeleteMessage
 from glue.core.subset import Subset
 from glue.core.subset_group import SubsetGroup, GroupedSubset
-
-from numpy import array, isin, unique
 
 class SubsetModifierListener(HubListener):
 
@@ -67,13 +65,9 @@ class SubsetModifierListener(HubListener):
 
     def _handle_message(self, message):
 
-        print("Got message")
-
         # Do we care about this message?
         if not self._should_listen(message):
             return
-
-        print("Should listen")
 
         # If we don't have a source yet, it's the subset from this message
         if self._source is None and isinstance(message, SubsetCreateMessage):

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -13,7 +13,10 @@ try:
 except ImportError:
     from astropy.cosmology import Planck15 as planck
 
-__all__ = ['age_in_gyr', 'load_template', 'update_figure_css', 'line_mark', 'vertical_line_mark']
+__all__ = [
+    'age_in_gyr', 'load_template', 'update_figure_css',
+    'extend_tool', 'line_mark', 'vertical_line_mark'
+]
 
 
 def age_in_gyr(H0):
@@ -62,7 +65,6 @@ def load_template(file_name, path=None, traitlet=True):
         return Unicode(TEMPLATE)
 
     return TEMPLATE
-
 
 def update_figure_css(viewer, style_dict=None, style_path=None):
     """
@@ -113,6 +115,45 @@ def update_figure_css(viewer, style_dict=None, style_path=None):
                 viewer_prop = getattr(layer, prop)
                 val = v[index % len(v)] if is_list else v
                 setattr(viewer_prop, k, val)
+
+def extend_tool(viewer, tool_id, activate_cb=None, deactivate_cb=None):
+    """
+    This function extends the functionality of a tool on a viewer toolbar
+    by adding callbacks that are activate upon tool item activation
+    and deactivation.
+
+    Parameters
+    ----------
+    viewer: `~glue.viewers.common.viewer.Viewer`
+        The glue viewer whose tool we want to modify.
+    tool_id: str
+        The id of the tool that we want to modify - e.g. 'bqplot:xrange'
+    activate_cb:
+        The callback to be executed before the tool's `activate` method. Takes no arguments.
+    deactivate_cb:
+        The callback to be executed after the tool's `deactivate` method. Takes no arguments.
+
+    """
+
+    tool = viewer.toolbar.tools.get(tool_id, None)
+    if not tool:
+        return None
+    
+    activate = tool.activate
+    deactivate = tool.deactivate
+
+    def extended_activate():
+        if activate_cb:
+            activate_cb()
+        activate()
+
+    def extended_deactivate():
+        deactivate()
+        if deactivate_cb:
+            deactivate_cb()
+    
+    tool.activate = extended_activate
+    tool.deactivate = extended_deactivate
 
 def line_mark(layer, start_x, start_y, end_x, end_y, color):
     """


### PR DESCRIPTION
This PR adds synchronization between the selection in the first histogram viewer on page 4 (that shows data for the students' class), and a subset in the scatter viewer on the same screen. Since the selection in the histogram is along the age component of the summary data, which we can't link to the individual student measurements, this is achieved via a custom listener (`HistogramListener`) descended from `glue.core.HubListener`.

Additionally, since a student won't have access to the standard glue UI, they won't be able to change the active subset in the usual way. To get around this, I've augmented the` activate` and `deactivate` methods for the x-range selector on the histogram viewer to set the active subset to the (only) subset defined on the histogram viewer when the tool is activate and unset the active subset when the tool is deactivated. The function that I used to do this is `extend_tool`, which was added to `utils.py` - I anticipate that we may need to do this for some of the other viewers in the story.

**Edit:** I also added a line fit to the student's selected subset (that vanishes when the selection is empty/deleted), as well as a button to let them clear their selection (necessary since they don't have access to the glue UI that one would typically use to do this).