### PR TITLE
Add functionality for students to 'draw' line

### DIFF
--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -2,7 +2,6 @@ from os.path import join
 from pathlib import Path
 
 from astropy.modeling import models, fitting
-from bqplot_image_gl import LinesGL
 from echo import CallbackProperty
 from echo.core import add_callback
 from glue.core.state_objects import State

--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -147,6 +147,10 @@ class Application(VuetifyTemplate):
             # Update the viewer CSS
             update_figure_css(viewer, style_path=style_path)
 
+        for viewer in hub_viewers:
+            # Set the bottom-left corner of the plot to be zero
+            viewer.state.x_min = 0
+            viewer.state.y_min = 0
         
         # Set up the viewer that will listen to the histogram
         hub_students_viewer.add_data(class_data)

--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -2,7 +2,6 @@ from os.path import join
 from pathlib import Path
 
 from astropy.modeling import models, fitting
-from bqplot_image_gl.interacts import MouseInteraction, mouse_events
 from bqplot_image_gl import LinesGL
 from echo import CallbackProperty
 from echo.core import add_callback
@@ -100,7 +99,6 @@ class Application(VuetifyTemplate):
         add_callback(self.state, 'class_histogram_selections', self._class_histogram_selection_update)
         add_callback(self.state, 'alldata_histogram_selections', self._alldata_histogram_selection_update)
         add_callback(self.state, 'sandbox_histogram_selections', self._sandbox_histogram_selection_update)
-        add_callback(self.state, 'draw_on', self._draw_on_changed)
 
         # Load the galaxy position data
         # This adds the file to the glue data collection at the top level
@@ -263,9 +261,7 @@ class Application(VuetifyTemplate):
         self._histogram_lines = {}
 
         # For letting the student draw a line
-        def turn_off_draw():
-            self.state.draw_on = False
-        self._line_draw_handler = LineDrawHandler(hub_fit_viewer, turn_off_draw)
+        self._line_draw_handler = LineDrawHandler(self, hub_fit_viewer)
         self._original_hub_fit_interaction = hub_fit_viewer.figure.interaction
 
         # scatter_viewer_layout = vuetify_layout_factory(gal_viewer)
@@ -602,20 +598,6 @@ class Application(VuetifyTemplate):
         toolbar = self._viewer_handlers['class_distr_viewer'].toolbar
         toolbar.active_tool = None
         self._histogram_listener.clear_subset()
-
-    def _draw_on_changed(self, draw_on):
-        viewer_id = 'hub_fit_viewer'
-        viewer = self._viewer_handlers[viewer_id]
-        figure = viewer.figure
-        if draw_on:
-            image = figure.marks[0]
-            scales_image = image.scales
-            interaction = MouseInteraction(x_scale=scales_image['x'], y_scale=scales_image['y'], move_throttle=70, next=None,
-                                events=mouse_events)
-            figure.interaction = interaction
-            interaction.on_msg(self._line_draw_handler.message_handler)
-        else:
-            figure.interaction = self._original_hub_fit_interaction
 
     # These three properties provide convenient access to the slopes of the the fit lines
     # for the student's data, the class's data, and all of the data

--- a/cosmicds/line_draw_handler.py
+++ b/cosmicds/line_draw_handler.py
@@ -95,10 +95,16 @@ class LineDrawHandler(object):
         self._endpt.opacities = [0]
 
     def _draw_on_changed(self, draw_on):
+
+        have_endpt = self._endpt is not None
+
+        if have_endpt:
+            self._endpt.opacities = [int(draw_on)]
+            self._endpt.hovered_style = {'cursor' : 'pointer'} if draw_on else {}
+
         if draw_on:
-            if self._endpt is not None:
+            if have_endpt:
                 self._viewer.figure.interaction = None
-                self._endpt.opacities = [1]
             else:
                 self._viewer.figure.interaction = self._interaction
         else:

--- a/cosmicds/line_draw_handler.py
+++ b/cosmicds/line_draw_handler.py
@@ -1,32 +1,36 @@
-from bqplot import ScatterGL
+from bqplot.marks import Scatter
 from bqplot_image_gl import LinesGL
+from bqplot_image_gl.interacts import MouseInteraction, mouse_events
+from echo.core import add_callback
 from math import sqrt
 
 class LineDrawHandler(object):
 
-    def __init__(self, viewer, done_editing):
+    def __init__(self, app, viewer):
+        self._app = app
         self._viewer = viewer
-        self._done_editing = done_editing
-        self._follow_pointer = False
+        self._follow_cursor = False
         self._drawn_line = None
-        self._drawn_line_endpt = None
+        self._endpt = None
 
-    def message_handler(self, interaction, data, buffers):
+        figure = viewer.figure
+        self._original_interaction = figure.interaction
+        scales_image = figure.marks[0].scales
+        self._interaction = MouseInteraction(x_scale=scales_image['x'], y_scale=scales_image['y'], move_throttle=70, next=None,
+                                events=mouse_events)
+        self._interaction.on_msg(self._message_handler)
+
+        add_callback(self._app.state, 'draw_on', self._draw_on_changed)
+
+    def _done_editing(self):
+        self._app.state.draw_on = False
+
+    def _message_handler(self, interaction, data, buffers):
         event_type = data['event']
         if event_type == 'mousemove':
             self._handle_mousemove(data)
         elif event_type == 'click':
             self._handle_click(data)
-
-
-    def _normalized_coordinates(self, data):
-        image = self.image
-        domain = data['domain']
-        domain_x = domain['x']
-        domain_y = domain['y']
-        normalized_x = (domain_x - image.x[0]) / (image.x[1] - image.x[0])
-        normalized_y = (domain_y - image.y[0]) / (image.y[1] - image.y[0])
-        return normalized_x, normalized_y
 
     def _circle_radius(self):
         viewer_range_x = self.viewer.state.x_max - self.viewer.state.x_min
@@ -36,49 +40,71 @@ class LineDrawHandler(object):
     def _handle_mousemove(self, data):
 
         image = self.figure.marks[0]
-        circle_radius = 10 # TODO: A real value here
-        normalized_x, normalized_y = self._normalized_coordinates(data)
-        print(self._drawn_line_endpt)
+        domain = data['domain']
+        x, y = domain['x'], domain['y']
 
         if self._drawn_line is None:
             self._drawn_line = LinesGL(x=[0, self.viewer.state.x_max], y=[0,0], scales=image.scales, colors=['black'])
             self.figure.marks = self.figure.marks + [self._drawn_line]
-            self._follow_pointer = True
-        elif self._drawn_line_endpt is not None:
-            delta_x = normalized_x - self._drawn_line_endpt.x[0]
-            delta_y = normalized_y - self._drawn_line_endpt.y[0]
+            self._follow_cursor = True
+        elif self._endpt is not None:
+            delta_x = x - self._endpt.x[0]
+            delta_y = y - self._endpt.y[0]
             dist = sqrt(delta_x ** 2 + delta_y ** 2)
-            opacity = 1 if dist <= self._circle_radius() else 0
-            print(opacity)
-            self._drawn_line_endpt.opacities = [opacity]
-            print(dist)
-            print(self._circle_radius())
+            #opacity = 1 if dist <= self._circle_radius() else 0
             
-        if self._follow_pointer:
-            self._drawn_line.x = [0, normalized_x]
-            self._drawn_line.y = [0, normalized_y]
+        if self._follow_cursor:
+            self._drawn_line.x = [0, x]
+            self._drawn_line.y = [0, y]
 
 
     def _handle_click(self, data):
-        if self._follow_pointer:
+        if self._follow_cursor:
 
             # Clear the old endpoint
-            normalized_x, normalized_y = self._normalized_coordinates(data)
-            self.figure.marks = [mark for mark in self.figure.marks if mark is not self._drawn_line_endpt]
+            domain = data['domain']
+            x, y = domain['x'], domain['y']
+            self.figure.marks = [mark for mark in self.figure.marks if mark is not self._endpt]
             
             # Add a new one
-            endpt = ScatterGL(x=[normalized_x], y=[normalized_y], color=['black'])
-            endpt.opacities = [1]
-            self.figure.marks = self.figure.marks + [endpt]
-            self._drawn_line_endpt = endpt
-            print("Making endpt: ", self._drawn_line_endpt)
+            image = self.figure.marks[0]
+            endpt = Scatter(x=[x],
+                              y=[y],
+                              colors=['black'],
+                              scales = {'x': image.scales['x'], 'y': image.scales['y']},
+                              interactions = {'click':'select'}
+                            )
+            endpt.on_element_click(self._on_endpt_click)
+            endpt.opacities = [0]
+
+            # If we don't put the endpoint first, it doesn't receive the click event
+            # Something (the ImageGL?) in front of it seems to be capturing that event
+            self.figure.marks = [endpt] + self.figure.marks
+            self._endpt = endpt
+            print("Making endpt: ", self._endpt)
 
             # End drawing
-            self._follow_pointer = False
+            self._follow_cursor = False
             self._done_editing()
-        elif self._drawn_line_endpt.visible:
-            self._follow_pointer = True
-            self._drawn_line_endpt.opacities = [1]
+
+    def _on_endpt_click(self, element, event):
+        print(element, event)
+        if not self._app.state.draw_on:
+            return
+
+        self._viewer.figure.interaction = self._interaction
+        self._follow_cursor = True
+        self._endpt.opacities = [0]
+
+    def _draw_on_changed(self, draw_on):
+        if draw_on:
+            if self._endpt is not None:
+                self._viewer.figure.interaction = None
+                self._endpt.opacities = [1]
+            else:
+                self._viewer.figure.interaction = self._interaction
+        else:
+            self._viewer.figure.interaction = self._original_interaction
 
     @property
     def viewer(self):

--- a/cosmicds/line_draw_handler.py
+++ b/cosmicds/line_draw_handler.py
@@ -78,6 +78,7 @@ class LineDrawHandler(object):
                               interactions = {'click':'select'}
                             )
             endpt.on_drag(self._on_endpt_drag)
+            endpt.on_drag_end(self._on_endpt_drag_end)
             endpt.opacities = [0]
             figure.marks = figure.marks + [endpt]
             self._endpt = endpt
@@ -85,6 +86,9 @@ class LineDrawHandler(object):
             # End drawing
             self._follow_cursor = False
             self._done_editing()
+
+    def _on_endpt_drag_end(self, element, event):
+        self._done_editing()
 
     def _on_endpt_drag(self, element, event):
         point = event["point"]

--- a/cosmicds/line_draw_handler.py
+++ b/cosmicds/line_draw_handler.py
@@ -77,6 +77,7 @@ class LineDrawHandler(object):
                               scales = {'x': image.scales['x'], 'y': image.scales['y']},
                               interactions = {'click':'select'}
                             )
+            endpt.on_drag_start(self._on_endpt_drag_start)
             endpt.on_drag(self._on_endpt_drag)
             endpt.on_drag_end(self._on_endpt_drag_end)
             endpt.opacities = [0]
@@ -86,6 +87,9 @@ class LineDrawHandler(object):
             # End drawing
             self._follow_cursor = False
             self._done_editing()
+
+    def _on_endpt_drag_start(self, element, event):
+        self._endpt.hovered_style = {'cursor' : 'grabbing'}
 
     def _on_endpt_drag_end(self, element, event):
         self._done_editing()
@@ -102,7 +106,7 @@ class LineDrawHandler(object):
 
         if have_endpt:
             self._endpt.opacities = [int(draw_on)]
-            self._endpt.hovered_style = {'cursor' : 'pointer'} if draw_on else {}
+            self._endpt.hovered_style = {'cursor' : 'grab'} if draw_on else {}
             self._endpt.enable_move = draw_on
 
         if draw_on:

--- a/cosmicds/line_draw_handler.py
+++ b/cosmicds/line_draw_handler.py
@@ -1,0 +1,93 @@
+from bqplot import ScatterGL
+from bqplot_image_gl import LinesGL
+from math import sqrt
+
+class LineDrawHandler(object):
+
+    def __init__(self, viewer, done_editing):
+        self._viewer = viewer
+        self._done_editing = done_editing
+        self._follow_pointer = False
+        self._drawn_line = None
+        self._drawn_line_endpt = None
+
+    def message_handler(self, interaction, data, buffers):
+        event_type = data['event']
+        if event_type == 'mousemove':
+            self._handle_mousemove(data)
+        elif event_type == 'click':
+            self._handle_click(data)
+
+
+    def _normalized_coordinates(self, data):
+        image = self.image
+        domain = data['domain']
+        domain_x = domain['x']
+        domain_y = domain['y']
+        normalized_x = (domain_x - image.x[0]) / (image.x[1] - image.x[0])
+        normalized_y = (domain_y - image.y[0]) / (image.y[1] - image.y[0])
+        return normalized_x, normalized_y
+
+    def _circle_radius(self):
+        viewer_range_x = self.viewer.state.x_max - self.viewer.state.x_min
+        viewer_range_y = self.viewer.state.y_max - self.viewer.state.y_min
+        return 0.01 * max(viewer_range_x, viewer_range_y)
+
+    def _handle_mousemove(self, data):
+
+        image = self.figure.marks[0]
+        circle_radius = 10 # TODO: A real value here
+        normalized_x, normalized_y = self._normalized_coordinates(data)
+        print(self._drawn_line_endpt)
+
+        if self._drawn_line is None:
+            self._drawn_line = LinesGL(x=[0, self.viewer.state.x_max], y=[0,0], scales=image.scales, colors=['black'])
+            self.figure.marks = self.figure.marks + [self._drawn_line]
+            self._follow_pointer = True
+        elif self._drawn_line_endpt is not None:
+            delta_x = normalized_x - self._drawn_line_endpt.x[0]
+            delta_y = normalized_y - self._drawn_line_endpt.y[0]
+            dist = sqrt(delta_x ** 2 + delta_y ** 2)
+            opacity = 1 if dist <= self._circle_radius() else 0
+            print(opacity)
+            self._drawn_line_endpt.opacities = [opacity]
+            print(dist)
+            print(self._circle_radius())
+            
+        if self._follow_pointer:
+            self._drawn_line.x = [0, normalized_x]
+            self._drawn_line.y = [0, normalized_y]
+
+
+    def _handle_click(self, data):
+        if self._follow_pointer:
+
+            # Clear the old endpoint
+            normalized_x, normalized_y = self._normalized_coordinates(data)
+            self.figure.marks = [mark for mark in self.figure.marks if mark is not self._drawn_line_endpt]
+            
+            # Add a new one
+            endpt = ScatterGL(x=[normalized_x], y=[normalized_y], color=['black'])
+            endpt.opacities = [1]
+            self.figure.marks = self.figure.marks + [endpt]
+            self._drawn_line_endpt = endpt
+            print("Making endpt: ", self._drawn_line_endpt)
+
+            # End drawing
+            self._follow_pointer = False
+            self._done_editing()
+        elif self._drawn_line_endpt.visible:
+            self._follow_pointer = True
+            self._drawn_line_endpt.opacities = [1]
+
+    @property
+    def viewer(self):
+        return self._viewer
+
+    @property
+    def figure(self):
+        return self.viewer.figure
+
+    @property
+    def image(self):
+        return self.figure.marks[0]

--- a/cosmicds/line_draw_handler.py
+++ b/cosmicds/line_draw_handler.py
@@ -77,7 +77,7 @@ class LineDrawHandler(object):
                               scales = {'x': image.scales['x'], 'y': image.scales['y']},
                               interactions = {'click':'select'}
                             )
-            endpt.on_element_click(self._on_endpt_click)
+            endpt.on_drag(self._on_endpt_drag)
             endpt.opacities = [0]
             figure.marks = figure.marks + [endpt]
             self._endpt = endpt
@@ -86,13 +86,11 @@ class LineDrawHandler(object):
             self._follow_cursor = False
             self._done_editing()
 
-    def _on_endpt_click(self, element, event):
-        if not self._app.state.draw_on:
-            return
-
-        self._viewer.figure.interaction = self._interaction
-        self._follow_cursor = True
-        self._endpt.opacities = [0]
+    def _on_endpt_drag(self, element, event):
+        point = event["point"]
+        x, y = point["x"], point["y"]
+        self._drawn_line.x = [0, x]
+        self._drawn_line.y = [0, y]
 
     def _draw_on_changed(self, draw_on):
 
@@ -101,6 +99,7 @@ class LineDrawHandler(object):
         if have_endpt:
             self._endpt.opacities = [int(draw_on)]
             self._endpt.hovered_style = {'cursor' : 'pointer'} if draw_on else {}
+            self._endpt.enable_move = draw_on
 
         if draw_on:
             if have_endpt:


### PR DESCRIPTION
This PR adds functionality for the student to 'draw' a best-fit line on screen 3 using their mouse. This works as follows:

- When the student first clicks the "Draw Fit Line" button, a listener is added to the scatter plot. This will follow the student's mouse inside the plot and create a line connecting their mouse location to the origin as they move.
- When the student clicks, this functionality is turned off, and their line stays in place. This click also deselects the "Draw Fit Line" button.
- When the student next clicks "Draw Fit Line", a circular point is added to the end of their line. If the student drags this point, they can adjust their line again. Until they do, their previous line is unaffected.

I think this is pretty close to what we had discussed the other day, but I can make changes to this if we think that this user experience isn't straightforward enough.