### PR TITLE
Fix issue with tests

### DIFF
--- a/cosmicds/tests/test_basic.ipynb
+++ b/cosmicds/tests/test_basic.ipynb
@@ -1,0 +1,42 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "source": [
+    "from cosmicds.app import Application\n",
+    "from glue.core.state_objects import State\n",
+    "\n",
+    "def test_instantiate():\n",
+    "    app = Application()\n",
+    "    return issubclass(type(app.state), State)"
+   ],
+   "outputs": [],
+   "metadata": {}
+  }
+ ],
+ "metadata": {
+  "orig_nbformat": 4,
+  "language_info": {
+   "name": "python",
+   "version": "3.9.7",
+   "mimetype": "text/x-python",
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "pygments_lexer": "ipython3",
+   "nbconvert_exporter": "python",
+   "file_extension": ".py"
+  },
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3.9.7 64-bit ('cds-test-fix': conda)"
+  },
+  "interpreter": {
+   "hash": "be6dfa053c100d5340b37ba82a9c797d1598809b9fda1ab4814b300c86f797b8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/cosmicds/tests/test_basic.py
+++ b/cosmicds/tests/test_basic.py
@@ -1,10 +1,10 @@
-import pytest
+from testbook import testbook
+from pathlib import Path
+from os.path import join
 
+directory = str(Path(__file__).parent)
 
-def test_instantiate():
-    from cosmicds.app import Application
-    from glue.core.state_objects import State
-
-    app = Application()
-
-    assert issubclass(type(app.state), State)
+@testbook(join(directory, "test_basic.ipynb"), execute=True)
+def test_instantiate(tb):
+    instantiate = tb.ref("test_instantiate")
+    assert instantiate()

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ test =
     pytest
     pytest-doctestplus
     pytest-cov
+    testbook
 docs =
     sphinx
     sphinx-automodapi


### PR DESCRIPTION
This PR fixes an issue with our testing setup that was caused by the recent `pywwt` release (0.13.0). This new release does some fun stuff with the Jupyter kernel to facilitate (among other things) the source selection functionality that we'll need, but the way it's doing it is causing the Jupyter widget to get a kernel of type `ipykernel.kernelbase.Kernel` (rather than `ipykernel.ipkernel.IPythonKernel`) when run outside of a Jupyter notebook, which means that it isn't getting the comm manager that it needs, hence the error.

To work around this, I've added [testbook](https://testbook.readthedocs.io/en/latest/) into our testing environment. Our test then has two parts: one, in `test_basic.ipynb`, which lives inside a Jupyter notebook, and another in `test_basic.py` which we can call from `pytest`. `testbook` can grab the function inside the Jupyter notebook, run it, and return the result back to the `.py` file for examination. Currently, the Jupyter test returns the result of our test as a `bool`, rather than returning the app and performing the test in `test_basic.py`, as I was having trouble getting `testbook` to serialize the `Application` object.