### PR TITLE
Improvements to measuring tool

### DIFF
--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -87,7 +87,6 @@ class ApplicationState(State):
     vels_total = CallbackProperty(0)
 
     haro_on = CallbackProperty("d-none")
-    galaxy_dist = CallbackProperty("")
     galaxy_vel = CallbackProperty("")
 
     calc_visible = CallbackProperty("d-none")
@@ -268,13 +267,13 @@ class Application(VuetifyTemplate):
         measuring_tool = MeasuringTool(measuring_widget)
         def update_state_ang_size(change):
             ang_size = change["new"]
-            ang_size_asec = int(ang_size.value * 3600)
+            ang_size_deg = ang_size.value if self.state.measuring_on else 0
+            ang_size_asec = int(ang_size_deg * 3600)
             self.state.measured_ang_size = ang_size_asec
-            self.state.measured_ang_size_str = format_measured_angle(ang_size) if ang_size.value != 0 else "-"
+            self.state.measured_ang_size_str = format_measured_angle(ang_size) if ang_size_deg != 0 else "-"
         measuring_tool.observe(update_state_ang_size, names=["angular_size"])
         def update_state_measuring(change):
             self.state.measuring_on = change["new"]
-            self.state.galaxy_dist = ""
             self.state.warn_size = False
         def update_measuring_height(change):
             self.state.measuring_tool_height = format_fov(change["new"])
@@ -1053,7 +1052,6 @@ class Application(VuetifyTemplate):
 
         self.state.warn_size = False
         distance_value = round(MILKY_WAY_SIZE_MPC / (self.state.measured_ang_size * pi / (180 * 3600)), 0)
-        self.state.galaxy_dist = distance_value
 
         data = self.data_collection['student_measurements']
         if test:

--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -34,7 +34,7 @@ from .components.dialog import Dialog
 from .components.table import Table
 from .viewers.spectrum_view import SpectrumView
 
-MEASUREMENT_THRESHOLD = 3000 # arcseconds
+MEASUREMENT_THRESHOLD = 1800 # arcseconds
 
 v.theme.dark = True
 v.theme.themes.dark.primary = 'colors.lightBlue.darken3'
@@ -268,7 +268,8 @@ class Application(VuetifyTemplate):
         measuring_tool = MeasuringTool(measuring_widget)
         def update_state_ang_size(change):
             ang_size = change["new"]
-            self.state.measured_ang_size = ang_size.value # In degrees
+            ang_size_asec = int(ang_size.value * 3600)
+            self.state.measured_ang_size = ang_size_asec
             self.state.measured_ang_size_str = format_measured_angle(ang_size) if ang_size.value != 0 else "-"
         measuring_tool.observe(update_state_ang_size, names=["angular_size"])
         def update_state_measuring(change):
@@ -1049,8 +1050,9 @@ class Application(VuetifyTemplate):
         if self.state.measured_ang_size >= MEASUREMENT_THRESHOLD:
             self.state.warn_size = True
             return
+
         self.state.warn_size = False
-        distance_value = round(MILKY_WAY_SIZE_MPC / (self.state.measured_ang_size * pi / 180), 0)
+        distance_value = round(MILKY_WAY_SIZE_MPC / (self.state.measured_ang_size * pi / (180 * 3600)), 0)
         self.state.galaxy_dist = distance_value
 
         data = self.data_collection['student_measurements']

--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -288,14 +288,16 @@ class Application(VuetifyTemplate):
         # Load the vue components through the ipyvuetify machinery. We add the
         # html tag we want and an instance of the component class as a
         # key-value pair to the components dictionary.
-        table_title = 'My Galaxies | Velocity Measurements'
+        velocity_title = 'My Galaxies | Velocity Measurements'
+        distance_title = 'My Galaxies | Distance Measurements'
+        fit_title = 'My Galaxies'
         self.components = {'c-footer': Footer(self),
                             'c-galaxy-table': Table(self.session, measurement_data, glue_components=self._galaxy_table_components,
-                                key_component='gal_name', names=galaxy_table_names, title=table_title, single_select=True),
+                                key_component='gal_name', names=galaxy_table_names, title=velocity_title, single_select=True),
                             'c-distance-table': Table(self.session, measurement_data, glue_components=self._distance_table_components,
-                                key_component='gal_name', names=distance_table_names, title=table_title, single_select=True),
+                                key_component='gal_name', names=distance_table_names, title=distance_title, single_select=True),
                             'c-fit-table': Table(self.session, student_data, glue_components=self._fit_table_components,
-                                key_component='gal_name', names=fit_table_names, title=table_title),
+                                key_component='gal_name', names=fit_table_names, title=fit_title),
                             'c-measuring-tool': measuring_tool,
                         # THE FOLLOWING REPLACED WITH video_dialog.vue component in data/vue_components
                         #    'c-dialog-vel': Dialog(

--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -272,10 +272,12 @@ class Application(VuetifyTemplate):
             ang_size_asec = int(ang_size_deg * 3600)
             self.state.measured_ang_size = ang_size_asec
             self.state.measured_ang_size_str = format_measured_angle(ang_size) if ang_size_deg != 0 else "-"
+            self.state.galaxy_dist = ""
         measuring_tool.observe(update_state_ang_size, names=["angular_size"])
         def update_state_measuring(change):
             self.state.measuring_on = change["new"]
             self.state.warn_size = False
+            self.state.galaxy_dist = ""
         def update_measuring_height(change):
             self.state.measuring_tool_height = format_fov(change["new"])
         def update_measuring_view_changing(change):

--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -122,6 +122,7 @@ class ApplicationState(State):
     measuring_tool_height = CallbackProperty("")
     measuring_view_changing = CallbackProperty(False)
     warn_size = CallbackProperty(False)
+    galaxy_dist = CallbackProperty("")
 
     fit_slopes = DictCallbackProperty()
 
@@ -1054,6 +1055,7 @@ class Application(VuetifyTemplate):
 
         self.state.warn_size = False
         distance_value = round(MILKY_WAY_SIZE_MPC / (self.state.measured_ang_size * pi / (180 * 3600)), 0)
+        self.state.galaxy_dist = str(int(distance_value))
 
         data = self.data_collection['student_measurements']
         if test:

--- a/cosmicds/app.py
+++ b/cosmicds/app.py
@@ -508,8 +508,6 @@ class Application(VuetifyTemplate):
                 widget.center_on_coordinates(coordinates, fov=0.016 * u.deg, instant=use_instant)
                 if not use_instant:
                     self.motions_left -= 1
-                else:
-                    measuring_tool.view_changing = False
                 self.state.measuring_name = name
                 self.state.measuring_type = gal_type.capitalize()
             

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -1011,7 +1011,7 @@
                                         <v-list-item-subtitle>field of view</v-list-item-subtitle>
                                       </v-list-item-content>
                                       <v-list-item-content>
-                                        <v-list-item-title>{{state.measured_ang_dist_str}}</v-list-item-title>
+                                        <v-list-item-title>{{state.measured_ang_size_str}}</v-list-item-title>
                                         <v-list-item-subtitle>measured angular size</v-list-item-subtitle>
                                       </v-list-item-content>
                                     </v-list>
@@ -1033,7 +1033,7 @@
                                       dark
                                       class="px-auto"
                                       max-width="100%"
-                                      :disabled="!state.measure_gal_selected || state.measured_ang_dist === 0"
+                                      :disabled="!state.measure_gal_selected || state.measured_ang_size === 0 || state.measuring_view_changing"
                                       @click="
                                         state.dist_measured = 1;
                                         state.gal_snackbar = 0;
@@ -1048,7 +1048,6 @@
                                           state.vel_measured == 1
                                             ? false
                                             : true;
-                                        state.galaxy_dist = +(0.03 / (state.measured_ang_dist * Math.PI / 180)).toFixed(0);
                                         add_distance_data_point();
                                       "
                                     >
@@ -1063,7 +1062,7 @@
                             <v-btn
                               class="white--text"
                               color="purple darken-2"
-                              :disabled="!state.measure_gal_selected"
+                              :disabled="!state.measure_gal_selected || state.measuring_view_changing"
                               @click="toggle_measuring()"
                             >{{ state.measuring_on ? "Stop Measuring" : "Start Measuring" }}
                             </v-btn>

--- a/cosmicds/app.vue
+++ b/cosmicds/app.vue
@@ -1059,6 +1059,11 @@
                             </v-col>
                           </v-row>
                           <v-row>
+                            <p
+                              v-if="state.warn_size"
+                              style="color: red;"
+                            >This angular size seems much larger than expected. Are you sure your measurements are lined up with a galaxy? Please try again.
+                            </p>
                             <v-btn
                               class="white--text"
                               color="purple darken-2"

--- a/cosmicds/components/measuring_tool/measuring_tool.py
+++ b/cosmicds/components/measuring_tool/measuring_tool.py
@@ -1,6 +1,7 @@
 import os
 import ipyvue as v
 from astropy.coordinates import Angle
+from astropy.coordinates.sky_coordinate import SkyCoord
 import astropy.units as u
 from cosmicds.utils import load_template
 from traitlets import Instance, Bool, Float, Int, Unicode, observe
@@ -20,17 +21,20 @@ class MeasuringTool(v.VueTemplate):
     widget = Instance(DOMWidget, allow_none=True).tag(sync=True, **widget_serialization)
     measuring = Bool().tag(sync=True)
     measuredDistance = Float().tag(sync=True)
-    angular_distance = Instance(Angle).tag(sync=True, to_json=angle_to_json, from_json=angle_from_json)
+    angular_size = Instance(Angle).tag(sync=True, to_json=angle_to_json, from_json=angle_from_json)
     angular_height = Instance(Angle).tag(sync=True, to_json=angle_to_json, from_json=angle_from_json)
     height = Int().tag(sync=True)
     width = Int().tag(sync=True)
+    view_changing = Bool().tag(sync=True)
+    _ra = Angle(0 * u.deg)
+    _dec = Angle(0 * u.deg)
 
     def __init__(self, wwt, *args, **kwargs):
         self.widget = wwt
         self.measuring = kwargs.get('measuring', False)
-        self.angular_distance = Angle(0, u.deg)
+        self.angular_size = Angle(0, u.deg)
         self.angular_height = Angle(60, u.deg)
-        self.widget._set_message_type_callback('wwt_view_state', self._on_fov_change)
+        self.widget._set_message_type_callback('wwt_view_state', self._handle_view_message)
         super().__init__(*args, **kwargs)
 
     def reset_canvas(self):
@@ -43,12 +47,20 @@ class MeasuringTool(v.VueTemplate):
     def _on_measured_distance_changed(self, change):
         fov = self.widget.get_fov()
         widget_height = self._height_from_pixel_str(self.widget.layout.height)
-        self.angular_distance = Angle(((change["new"] / widget_height) * fov))
+        self.angular_size = Angle(((change["new"] / widget_height) * fov))
 
     @observe('measuring')
     def _on_measuring_changed(self, measuring):
         if not measuring["new"]:
             self.reset_canvas()
 
-    def _on_fov_change(self, wwt, _updated):
-        self.angular_height = Angle(self.widget.get_fov())
+    def _handle_view_message(self, wwt, _updated):
+        fov = Angle(self.widget.get_fov())
+        center = self.widget.get_center()
+        ra = Angle(center.ra)
+        dec = Angle(center.dec)
+        changing = not u.allclose([fov, ra, dec], [self.angular_height, self._ra, self._dec])
+        self.angular_height = fov
+        self._ra = ra
+        self._dec = dec
+        self.view_changing = changing

--- a/cosmicds/components/measuring_tool/measuring_tool.py
+++ b/cosmicds/components/measuring_tool/measuring_tool.py
@@ -3,9 +3,11 @@ import ipyvue as v
 from astropy.coordinates import Angle
 from astropy.coordinates.sky_coordinate import SkyCoord
 import astropy.units as u
-from cosmicds.utils import load_template
+from cosmicds.utils import RepeatedTimer, load_template
 from traitlets import Instance, Bool, Float, Int, Unicode, observe
 from ipywidgets import DOMWidget, widget_serialization
+from datetime import datetime
+
 
 def angle_to_json(angle, _widget):
     return {
@@ -35,6 +37,8 @@ class MeasuringTool(v.VueTemplate):
         self.angular_size = Angle(0, u.deg)
         self.angular_height = Angle(60, u.deg)
         self.widget._set_message_type_callback('wwt_view_state', self._handle_view_message)
+        self.last_update = datetime.now()
+        self._rt = RepeatedTimer(1, self._check_measuring_allowed)
         super().__init__(*args, **kwargs)
 
     def reset_canvas(self):
@@ -42,6 +46,16 @@ class MeasuringTool(v.VueTemplate):
 
     def _height_from_pixel_str(self, s):
         return int(s[:-2]) # Remove the 'px' from the end
+
+    # We aren't always guaranteed to get an update from the WWT viewer
+    # so every second, if the view is marked as changing, 
+    # we check when the last update that we got is
+    # If it's more than a second old, mark the view as not changing
+    def _check_measuring_allowed(self):
+        if self.view_changing:
+            delta = datetime.now() - self.last_update
+            if delta.total_seconds() >= 1:
+                self.view_changing = False
 
     @observe('measuredDistance')
     def _on_measured_distance_changed(self, change):
@@ -64,3 +78,4 @@ class MeasuringTool(v.VueTemplate):
         self._ra = ra
         self._dec = dec
         self.view_changing = changing
+        self.last_update = datetime.now()

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -8,6 +8,7 @@ from glue_jupyter.bqplot.histogram.layer_artist import BqplotHistogramLayerArtis
 from glue_jupyter.bqplot.scatter.layer_artist import BqplotScatterLayerArtist
 import numpy as np
 from traitlets import Unicode
+from threading import Timer
 
 try:
     from astropy.cosmology import Planck18 as planck
@@ -15,13 +16,38 @@ except ImportError:
     from astropy.cosmology import Planck15 as planck
 
 __all__ = [
-    'MILKY_WAY_SIZE_MPC',
+    'MILKY_WAY_SIZE_MPC', 'RepeatedTimer',
     'age_in_gyr', 'load_template', 'update_figure_css',
      'extend_tool', 'format_fov', 'format_measured_angle',
     'line_mark', 'vertical_line_mark',
 ]
 
 MILKY_WAY_SIZE_MPC = 0.03
+
+class RepeatedTimer(object):
+    def __init__(self, interval, function, *args, **kwargs):
+        self._timer     = None
+        self.interval   = interval
+        self.function   = function
+        self.args       = args
+        self.kwargs     = kwargs
+        self.is_running = False
+        self.start()
+
+    def _run(self):
+        self.is_running = False
+        self.start()
+        self.function(*self.args, **self.kwargs)
+
+    def start(self):
+        if not self.is_running:
+            self._timer = Timer(self.interval, self._run)
+            self._timer.start()
+            self.is_running = True
+
+    def stop(self):
+        self._timer.cancel()
+        self.is_running = False
 
 def age_in_gyr(H0):
     """

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -15,10 +15,13 @@ except ImportError:
     from astropy.cosmology import Planck15 as planck
 
 __all__ = [
+    'MILKY_WAY_SIZE_MPC',
     'age_in_gyr', 'load_template', 'update_figure_css',
-    'extend_tool', 'line_mark', 'vertical_line_mark'
+     'extend_tool', 'format_fov', 'format_measured_angle',
+    'line_mark', 'vertical_line_mark',
 ]
 
+MILKY_WAY_SIZE_MPC = 0.03
 
 def age_in_gyr(H0):
     """

--- a/cosmicds/utils.py
+++ b/cosmicds/utils.py
@@ -24,6 +24,7 @@ __all__ = [
 
 MILKY_WAY_SIZE_MPC = 0.03
 
+# JC: I got this from https://stackoverflow.com/a/13151299
 class RepeatedTimer(object):
     def __init__(self, interval, function, *args, **kwargs):
         self._timer     = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ include_package_data = True
 install_requires = 
   glue-core
   glue-jupyter
+  pywwt <= 0.14
   glue-wwt
   pyqt5
   PyQtWebEngine


### PR DESCRIPTION
This PR makes a few tweaks and improvements to the measuring tool. These changes are:

* If the view in the tool's WWT viewer is changing (moving or zooming), measuring is disallowed. The WWT widget doesn't have a built-in notion of 'view is changing', so I've implemented this by monitoring the RA, Dec, and FOV of the widget. When the widget gets an update, if any of these values has changed, the view is considered to be changing.
    - We aren't always guaranteed to get an update from the widget if the view doesn't change (in particular, this happens when the student clicks on a galaxy and the movement is via the widget's `center_on_coordinates` method). To get around this, the measuring tool keeps track of when it last got an update from the widget. If that time is longer than some threshold time (currently one second), the tool interprets that as the widget view not changing.
* The measuring tool will jump directly to a galaxy starting with the third galaxy the student selects (currently, this is set to the fourth galaxy).
* If the student's measured angular size exceeds half a degree, they get a warning, and the value is not added to their data set. On the backend, `state.warn_size` is set to True. Currently a `<p>` element with red text displays this color.
* Modified the titles of the tables on the second screen (where the tool is) as well as the third screen.

Finally, while v0.15 of pywwt is released, there seem to be some issues with using it in the app. Until I figure those out, I've set `pywwt <= 0.14` in `setup.cfg`.